### PR TITLE
ログイン状態の出品者のみ商品情報を削除できる。

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,8 +25,10 @@ class ItemsController < ApplicationController
 
     def destroy
       item = Item.find(params[:id])
+       if current_user.id
       item.destroy
       redirect_to root_path
+       end
     end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,7 +25,7 @@ class ItemsController < ApplicationController
 
     def destroy
       item = Item.find(params[:id])
-       if current_user.id
+       if current_user.id == item.user_id
       item.destroy
       redirect_to root_path
        end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,12 @@ class ItemsController < ApplicationController
       @item = Item.find(params[:id])
     end
 
+    def destroy
+      item = Item.find(params[:id])
+      item.destroy
+      redirect_to root_path
+    end
+
   private
   def item_params
     params.require(:item).permit(:name, :item_explanation, :price, :prefecture_id,:shipping_date_id,:status_id,:category_id,:delivery_fee_id, :image).merge(user_id: current_user.id)

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
       <% if current_user.id == @item.user_id%>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
 
     <% else  %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>


### PR DESCRIPTION
#What
ログイン状態の出品者の情報を削除できる


#Why
ユーザーが間違って出品してしまった際に、取り消しができるようにするため。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画になります。
https://gyazo.com/dc52023024736c71d34ec072e10df6ad
